### PR TITLE
feat: display vacation banner

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -1,7 +1,7 @@
 const Banner = () => {
   return (
     <div className='bg-[#d9534f] text-white py-2 text-center z-20'>
-      Cerramos por vacaciones del 21 al 30 de abril.
+      Estamos cerrados del 11 al 24 de agosto.
     </div>
   )
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,11 @@
 import NavMenu from './NavMenu'
 import SocialNetIcons from './SocialNetIcons'
-// import Banner from './Banner'
+import Banner from './Banner'
 
 const Header = () => {
   return (
     <>
-      {/* <Banner /> */}
+      <Banner />
       <header className='w-full flex items-center justify-around px-6 py-4 bg-[#515d4f] shadow-md h-[20vh] gap-2 basis-1/4 relative'>
         <div className='md:basis-1/4'>
           <SocialNetIcons />


### PR DESCRIPTION
## Summary
- show banner with August closing dates
- enable banner in header for site-wide visibility

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` and `Roboto` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689762abf4108323b67f077b1fee4740